### PR TITLE
Harden filter-repo rewrites by using "--refs"

### DIFF
--- a/gitprivacy/gitprivacy.py
+++ b/gitprivacy/gitprivacy.py
@@ -301,7 +301,8 @@ def do_redate(ctx: click.Context, startpoint: str,
             err=True
         )
         ctx.exit(3)
-    with click.progressbar(commits, label="Redating commits") as bar:
+    # add commits in reversed order to rewriter startpoint first, HEAD last
+    with click.progressbar(reversed(commits), label="Redating commits") as bar:
         for commit in bar:
             rewriter.update(commit)
     rewriter.finish()
@@ -324,9 +325,11 @@ def redate_rewrites(ctx: click.Context):
     # determine commits to redate
     with open(rewrites_log_path, "r") as rwlog_fp:
         rwlog = list(map(_parse_post_rewrite_format, rwlog_fp))
-    olds = set(e[0] for e in rwlog)
-    news = set(e[1] for e in rwlog)
-    pending = news.difference(olds)  # ignore already rewritten news
+    olds_set = set(e[0] for e in rwlog)
+    news = [e[1] for e in rwlog]
+    news_set = set(news)
+    pending_set = news_set.difference(olds_set)  # ignore already rewritten news
+    pending = [noid for noid in news if noid in pending_set]
 
     if len(pending) == 0:
         click.echo("No pending rewrites to redact")

--- a/gitprivacy/rewriter/filterrewriter.py
+++ b/gitprivacy/rewriter/filterrewriter.py
@@ -4,7 +4,7 @@ Bulk rewriting of Git history using git-filter-repo
 import git  # type: ignore
 import git_filter_repo as fr  # type: ignore
 
-from typing import Set
+from typing import List, Set
 
 from . import Rewriter
 from .. import utils
@@ -17,15 +17,20 @@ class FilterRepoRewriter(Rewriter):
     def __init__(self, repo: git.Repo, encoder: Encoder,
                  replace: bool = False) -> None:
         super().__init__(repo, encoder, replace)
-        self.commits_to_rewrite: Set[str] = set()
+        self.commits_to_rewrite: List[git.Commit] = []
+        self.commits_oid_set: Set[str] = set()
+        self.with_initial_commit = False
 
 
     def update(self, commit: git.Commit) -> None:
-        self.commits_to_rewrite.add(commit.hexsha)
+        if not commit.parents:
+            self.with_initial_commit = True
+        self.commits_to_rewrite.append(commit)
+        self.commits_oid_set.add(commit.hexsha)
 
     def _rewrite(self, commit: fr.Commit, _metadata) -> None:
         hexid = commit.original_id.decode()
-        if hexid not in self.commits_to_rewrite:
+        if hexid not in self.commits_oid_set:
             # do nothing
             return
         g_commit = self.repo.commit(hexid)  # get pygit Commit object
@@ -37,15 +42,33 @@ class FilterRepoRewriter(Rewriter):
 
 
     def finish(self) -> None:
+        if not self.commits_to_rewrite:
+            return  # nothing to do
         if self.replace:
             replace_opt = "update-or-add"
         else:
             replace_opt = "update-no-add"
+        # Use reference based names instead of OIDs.
+        # This avoid Git's object name warning and
+        # otherwise filter-repo fails to replace the objects.
+        def rev_name(commit: git.Commit) -> str:
+            return commit.name_rev.split()[1]
+        first = self.commits_to_rewrite[0]
+        last = self.commits_to_rewrite[-1]
+        assert first == last or first in last.iter_parents(), "Wrong commit order"
+        first_rev = rev_name(first)
+        last_rev = rev_name(last)
+        if self.with_initial_commit:
+            refs = last_rev
+        else:
+            refs = f"{first_rev}^..{last_rev}"  # ^ to include 'first' in the range
         args = fr.FilteringOptions.parse_args([
             '--source', self.repo.git_dir,
             '--force',
             '--quiet',
+            '--preserve-commit-encoding',
             '--replace-refs', replace_opt,
+            '--refs', refs,
         ])
         rfilter = fr.RepoFilter(args, commit_callback=self._rewrite)
         rfilter.run()

--- a/tests/test_gitprivacy.py
+++ b/tests/test_gitprivacy.py
@@ -1038,7 +1038,10 @@ class TestGitPrivacy(unittest.TestCase):
             self.assertNotRegex(cm.exception.stderr, r"(?m)^WARNING:")
             # again, redate local changes and then push – should work
             result = self.invoke('redate origin/master')
+            #self.assertEqual(result.output, "")
             self.assertEqual(result.exit_code, 0)
+            cr = self.repo.head.commit
+            self.assertNotEqual(cr.hexsha, c.hexsha)
             res, _stdout, _stderr = self.git.push(
                 [remote.name, self.repo.active_branch],
                 with_extended_output=True,


### PR DESCRIPTION
This tells filter-repo to only do a partial history rewrite of
the specified references.

Before filter-repo would – under some unclear circumstances – rewrite
more than the commits changed by the commit-callback which lead to
unexpected diverging histories (#22).